### PR TITLE
docs: evm.chains.mainnet.constants error  (#490)

### DIFF
--- a/docs/building_chains.rst
+++ b/docs/building_chains.rst
@@ -20,13 +20,13 @@ class:
   from evm import constants, Chain
   from evm.vm.forks.frontier import FrontierVM
   from evm.vm.forks.homestead import HomesteadVM
-  import evm.chains.mainnet as mainnet
+  from evm.chains.mainnet import HOMESTEAD_MAINNET_BLOCK
 
   chain_class = Chain.configure(
       __name__='Test Chain',
       vm_configuration=(
           (constants.GENESIS_BLOCK_NUMBER, FrontierVM),
-          (mainnet.constants.HOMESTEAD_MAINNET_BLOCK, HomesteadVM),
+          (HOMESTEAD_MAINNET_BLOCK, HomesteadVM),
       ),
   )
 


### PR DESCRIPTION
* add to gitignre

* add to .gitignore

* .new gitignore

* test

* add to .gitignore_

* maintain HOMESTEAD_MAINNET_BLOCK in building_chains docs

* gitignore

### What was wrong?



### How was it fixed?



#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
